### PR TITLE
[WIP] Start of settings section

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,6 +1,7 @@
 <?php
 
 OCP\Util::addStyle('unsplash', 'login');
+OCP\Util::addStyle('unsplash', 'header');
 
 $manager = \OC::$server->getContentSecurityPolicyManager();
 $policy = new \OC\Security\CSP\ContentSecurityPolicy();

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,19 +5,28 @@
     <name>Unsplash</name>
     <summary>📸🔀☁️ Random background from Unsplash</summary>
     <description>Show a new random featured nature photo from Unsplash on the log in screen and in the header.</description>
+
     <licence>AGPL</licence>
     <author mail="hey@jancborchardt.net" homepage="http://jancborchardt.net">Jan-Christoph Borchardt</author>
     <version>1.1.1</version>
     <namespace>Unsplash</namespace>
+
     <category>customization</category>
     <category>multimedia</category>
     <category>tools</category>
+
     <website>https://github.com/jancborchardt/unsplash/</website>
     <bugs>https://github.com/jancborchardt/unsplash/issues</bugs>
     <repository type="git">https://github.com/jancborchardt/unsplash.git</repository>
+
     <screenshot>https://raw.githubusercontent.com/jancborchardt/unsplash/master/unsplash.jpg</screenshot>
     <screenshot>https://raw.githubusercontent.com/jancborchardt/unsplash/master/unsplash-header.jpg</screenshot>
+
     <dependencies>
         <nextcloud min-version="11" max-version="14"/>
     </dependencies>
+
+    <settings>
+		<admin>OCA\Unsplash\Settings\Admin</admin>
+	</settings>
 </info>

--- a/css/header.css
+++ b/css/header.css
@@ -11,6 +11,8 @@
 /* Header icons get drop shadow for visibility */
 #header .logo.logo-icon,
 #appmenu svg,
+#more-apps div,
+.searchbox input[type="search"],
 .notifications .notifications-button img,
 #contactsmenu .icon-contacts,
 #expand .avatardiv-shown img,
@@ -20,8 +22,11 @@
 }
 
 /* Header icons get higher opacity for visibility */
-#appmenu li a {
-	opacity: .8;
+#appmenu li a,
+.searchbox input[type="search"],
+#header .header-right > div > .menutoggle,
+#header .header-right > form > .menutoggle {
+	opacity: .9;
 }
 
 .searchbox input[type="search"]:focus,

--- a/css/header.css
+++ b/css/header.css
@@ -1,0 +1,32 @@
+#body-user #header,
+#body-settings #header,
+#body-public #header {
+	background-color: #777 !important;
+	background-image: url('https://source.unsplash.com/random/featured/?nature') !important;
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: cover;
+}
+
+/* Header icons get drop shadow for visibility */
+#header .logo.logo-icon,
+#appmenu svg,
+.notifications .notifications-button img,
+#contactsmenu .icon-contacts,
+#expand .avatardiv-shown img,
+#expand .expandDisplayName {
+	 /* Modified .icon-shadow with modified $color-box-shadow */
+    filter: drop-shadow(0 0 3px rgba(50, 50, 50, .5)) !important;
+}
+
+/* Header icons get higher opacity for visibility */
+#appmenu li a {
+	opacity: .8;
+}
+
+.searchbox input[type="search"]:focus,
+.searchbox input[type="search"]:active,
+.searchbox input[type="search"]:valid {
+	background-color: rgba(0, 0, 0, .5) !important;
+	border: none !important
+}

--- a/css/login.css
+++ b/css/login.css
@@ -1,7 +1,4 @@
-#body-login,
-#body-user #header,
-#body-settings #header,
-#body-public #header {
+#body-login {
 	background-color: #777 !important;
 	background-image: url('https://source.unsplash.com/random/featured/?nature') !important;
 	background-position: center;
@@ -13,27 +10,4 @@
 #body-login button.primary,
 #body-login #alternative-logins li a {
     background-color: rgba(0, 0, 0, .5) !important;
-}
-
-/* Header icons get drop shadow for visibility */
-#header .logo.logo-icon,
-#appmenu svg,
-.notifications .notifications-button img,
-#contactsmenu .icon-contacts,
-#expand .avatardiv-shown img,
-#expand .expandDisplayName {
-	 /* Modified .icon-shadow with modified $color-box-shadow */
-    filter: drop-shadow(0 0 3px rgba(50, 50, 50, .5)) !important;
-}
-
-/* Header icons get higher opacity for visibility */
-#appmenu li a {
-	opacity: .8;
-}
-
-.searchbox input[type="search"]:focus,
-.searchbox input[type="search"]:active,
-.searchbox input[type="search"]:valid {
-	background-color: rgba(0, 0, 0, .5) !important;
-	border: none !important
 }

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -1,0 +1,9 @@
+$(function() {
+	$('#headerbackground').on('change', function() {
+		var status = 'no';
+		if ($(this).is(':checked')) {
+			status = 'yes';
+		}
+		OCP.AppConfig.setValue('unsplash', 'headerbackground', status);
+	});
+});

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Unsplash\AppInfo;
+
+
+use OCA\Unsplash\Settings;
+use OCP\AppFramework\App;
+use OCP\Util;
+use OCA\Unsplash\Capabilities;
+
+class Application extends App {
+
+	public function __construct(array $urlParams = array()) {
+		parent::__construct('unsplash', $urlParams);
+
+		$settingsManager = \OC::$server->query(Settings\SettingsManager::class);
+		$settings = new Settings($settingsManager);
+
+		/** register capabilities */
+		$container = $this->getContainer();
+		$container->registerCapability(Capabilities::class);
+
+		/** register hooks */
+		Util::connectHook('\OCP\Config', 'js', $settings, 'announceUnsplashSettings');
+	}
+
+}

--- a/lib/Settings.php
+++ b/lib/Settings.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Unsplash;
+
+
+use OCA\Unsplash\Settings\SettingsManager;
+
+class Settings {
+
+	/** @var SettingsManager */
+	private $settingsManager;
+
+	public function __construct(SettingsManager $settingsManager) {
+		$this->settingsManager = $settingsManager;
+	}
+
+	/**
+	 * announce that the share-by-mail share provider is enabled
+	 *
+	 * @param array $settings
+	 */
+	public function announceUnsplashSettings(array $settings) {
+		$array = json_decode($settings['array']['oc_appconfig'], true);
+		$array['unsplash']['headerbackground'] = $this->settingsManager->headerbackground();
+		$settings['array']['oc_appconfig'] = json_encode($array);
+	}
+}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Unsplash\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Settings\ISettings;
+
+class Admin implements ISettings {
+
+	/** @var SettingsManager */
+	private $settingsManager;
+
+	public function __construct(SettingsManager $settingsManager) {
+		$this->settingsManager = $settingsManager;
+	}
+
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+
+		$parameters = [
+			'headerbackground' => $this->settingsManager->headerbackground()
+		];
+
+		return new TemplateResponse('unsplash', 'settings-admin', $parameters, '');
+	}
+
+	/**
+	 * @return string the section ID, e.g. 'sharing'
+	 */
+	public function getSection() {
+		return 'theming';
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 * the admin section. The forms are arranged in ascending order of the
+	 * priority values. It is required to return a value between 0 and 100.
+	 *
+	 * E.g.: 70
+	 */
+	public function getPriority() {
+		return 40;
+	}
+
+}

--- a/lib/Settings/SettingsManager.php
+++ b/lib/Settings/SettingsManager.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Unsplash\Settings;
+
+
+use OCP\IConfig;
+
+class SettingsManager {
+
+	/** @var IConfig */
+	private $config;
+
+	private $headerbackgroundDefault = 'yes';
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Should the header when logged in or sharing also have a background image
+	 *
+	 * @return bool
+	 */
+	public function headerbackground() {
+		$headerbackground = $this->config->getAppValue('unsplash', 'headerbackground', $this->headerbackgroundDefault);
+		return $headerbackground === 'yes';
+	}
+
+}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -1,0 +1,15 @@
+<?php
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
+script('unsplash', 'settings-admin');
+?>
+<div id="unsplash-settings" class="section">
+	<h2><?php p($l->t('Unsplash')); ?></h2>
+	<p class="settings-hint"><?php p($l->t('Shows a random nature image at log in and in the header.')); ?></p>
+
+	<p>
+		<input id="headerbackground" type="checkbox" class="checkbox" <?php if($_['headerbackground']) p('checked'); ?> />
+		<label for="headerbackground"><?php p($l->t('Enable background in header')); ?></label>
+	</p>
+
+</div>


### PR DESCRIPTION
@schiessle @MorrisJobke I copied the settings code from the [sharebymail app](https://github.com/nextcloud/server/tree/master/apps/sharebymail). The last thing missing is to link up the actual functionality. Can you give me pointers here? :)

By default the header.css should be loaded (as loaded in the [app.php](https://github.com/jancborchardt/unsplash/compare/settings?expand=1#diff-079bbe455bfa9aeaf363ae1bc6415ba0R4)), but when the checkbox (in »Theming« admin settings) is unchecked, the header background should be disabled.

And I’m guessing I also don’t need some of the stuff, like Capabilities?