### PR TITLE
Update max-version to upcoming development version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ source_dir=$(build_dir)/source
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
-version+=1.1.1
+version+=1.1.2
 
 all: appstore
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,9 +7,9 @@
     <summary lang="de">📸🔀☁️ Zufällige Hintergrundbilder von Unsplash</summary>
     <description>Show a new random featured nature photo from Unsplash on the log in screen and (optionally) in the header.</description>
     <description lang="de">Zeigt ein zufällig ausgewähltes Naturfoto von Unsplash auf dem Anmeldebildschirm und (optional) in der Navigationsleiste an.</description>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <licence>agpl</licence>
-    <author mail="hey@jancborchardt.net" homepage="http://jancborchardt.net">Jan-Christoph Borchardt</author>
+    <author mail="hey@jancborchardt.net" homepage="https://jancborchardt.net">Jan-Christoph Borchardt</author>
     <namespace>Unsplash</namespace>
     <category>customization</category>
     <category>multimedia</category>
@@ -21,7 +21,7 @@
     <screenshot>https://raw.githubusercontent.com/jancborchardt/unsplash/master/unsplash-header.jpg</screenshot>
     <dependencies>
         <php min-version="7.0" />
-        <nextcloud min-version="11" max-version="14"/>
+        <nextcloud min-version="13" max-version="16"/>
     </dependencies>
     <settings>
         <admin>OCA\Unsplash\Settings\AdminSettings</admin>


### PR DESCRIPTION
The app already works fine with Nextcloud 14, close https://github.com/jancborchardt/unsplash/issues/25

This makes sure it also works on development instances when 14 is out and the version will be 15. Please review @ChristophWurst @auberginepop @newhinton :tada: 