### PR TITLE
Up min-version, add co-authors

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@
     <screenshot>https://raw.githubusercontent.com/jancborchardt/unsplash/master/unsplash-header.jpg</screenshot>
     <dependencies>
         <php min-version="7.0" />
-        <nextcloud min-version="13" max-version="16"/>
+        <nextcloud min-version="14" max-version="16"/>
     </dependencies>
     <settings>
         <admin>OCA\Unsplash\Settings\AdminSettings</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,6 +10,8 @@
     <version>1.1.3</version>
     <licence>agpl</licence>
     <author mail="hey@jancborchardt.net" homepage="https://jancborchardt.net">Jan-Christoph Borchardt</author>
+    <author homepage="https://github.com/marius-wieschollek">Marius Wieschollek</author>
+    <author homepage="https://github.com/newhinton">Felix Nüsse</author>
     <namespace>Unsplash</namespace>
     <category>customization</category>
     <category>multimedia</category>


### PR DESCRIPTION
- Upping the min-version to Nextcloud 14 as discussed in https://github.com/jancborchardt/unsplash/issues/36
- Adding @newhinton & @marius-wieschollek to authors. ;)

Please review and check if you want to add your email address or have a different website displayed (used your Github profile link).